### PR TITLE
Use informative tempfile names for build artifacts

### DIFF
--- a/artifact_test.go
+++ b/artifact_test.go
@@ -1,0 +1,28 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/hashrabbit/circleci-runner"
+	circleci "github.com/jszwedko/go-circleci"
+)
+
+func TestArtifactHasInformativeName(t *testing.T) {
+	a := &Artifact{
+		Artifact: &circleci.Artifact{
+			Path: "foo/bar/baz/main",
+		},
+		Build: &circleci.Build{
+			BuildNum:    123,
+			Username:    "acme",
+			Reponame:    "widgets",
+			VcsRevision: "abc123487915bf84c7c67a653c55aad148dfa508",
+		},
+	}
+
+	expected := "acme-widgets-123-gabc1234_main"
+	actual := a.Name()
+	if actual != expected {
+		t.Errorf("expected artifact name to be %q, got %q", expected, actual)
+	}
+}


### PR DESCRIPTION
Tempfile names for build artifacts are now a bit more informative. File names are formatted as:

    <username>-<reponame>-<build_num>-g<commit>_<artifact_path>

For example: `acme-widgets-123-gabc1234_main`

Fixes #8